### PR TITLE
Fix Mailchimp list member sync (subscriber hash, status_if_new, interest pagination)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    effective_mailchimp (0.13.0)
+    effective_mailchimp (0.13.2)
       MailchimpMarketing
       effective_bootstrap
       effective_datatables (>= 4.0.0)
@@ -391,7 +391,6 @@ DEPENDENCIES
   effective_test_bot
   haml-rails
   pry-byebug
-  psych
   sqlite3
   wicked
 

--- a/app/models/effective/mailchimp_api.rb
+++ b/app/models/effective/mailchimp_api.rb
@@ -3,6 +3,7 @@
 # https://mailchimp.com/developer/marketing/api/
 
 require 'MailchimpMarketing'
+require 'digest'
 
 module Effective
   class MailchimpApi
@@ -92,7 +93,7 @@ module Effective
       Rails.logger.info "[effective_mailchimp] Get List Member" if debug?
 
       begin
-        client.lists.get_list_member(id.try(:mailchimp_id) || id, email)
+        client.lists.get_list_member(id.try(:mailchimp_id) || id, subscriber_hash(email))
       rescue MailchimpMarketing::ApiError => e
         {}
       end
@@ -129,7 +130,7 @@ module Effective
 
       # Actually add or update
       payload = list_member_payload(member)
-      client.lists.set_list_member(member.mailchimp_list.mailchimp_id, member.email, payload)
+      client.lists.set_list_member(member.mailchimp_list.mailchimp_id, subscriber_hash(member.user.email), payload)
     end
 
     def list_member_update(member)
@@ -139,7 +140,8 @@ module Effective
       return if sandbox_mode?
 
       payload = list_member_payload(member)
-      client.lists.update_list_member(member.mailchimp_list.mailchimp_id, member.email, payload)
+      hash = member.mailchimp_id.presence || subscriber_hash(member.email)
+      client.lists.update_list_member(member.mailchimp_list.mailchimp_id, hash, payload)
     end
 
     def list_member_payload(member)
@@ -154,6 +156,13 @@ module Effective
         merge_fields: merge_fields.transform_values { |value| value || '' },
         interests: member.interests_hash.presence
       }.compact
+    end
+
+    # Mailchimp identifies a list member by the MD5 hash of their lowercase email address
+    def subscriber_hash(email)
+      raise('expected an email') unless email.to_s.include?('@')
+
+      Digest::MD5.hexdigest(email.to_s.downcase.strip)
     end
 
   end

--- a/app/models/effective/mailchimp_api.rb
+++ b/app/models/effective/mailchimp_api.rb
@@ -76,14 +76,14 @@ module Effective
     def categories(list_id)
       Rails.logger.info "[effective_mailchimp] Index Interest Categories" if debug?
 
-      response = client.lists.get_list_interest_categories(list_id.try(:mailchimp_id) || list_id)
+      response = client.lists.get_list_interest_categories(list_id.try(:mailchimp_id) || list_id, count: 1000)
       Array(response['categories']) - [nil, '', {}]
     end
 
     def interests(list_id, category_id)
       Rails.logger.info "[effective_mailchimp] Index Interest Category Interests" if debug?
 
-      response = client.lists.list_interest_category_interests(list_id, category_id)
+      response = client.lists.list_interest_category_interests(list_id, category_id, count: 1000)
       Array(response['interests']) - [nil, '', {}]
     end
 

--- a/app/models/effective/mailchimp_api.rb
+++ b/app/models/effective/mailchimp_api.rb
@@ -128,8 +128,8 @@ module Effective
       Rails.logger.info "[effective_mailchimp] Add List Member" if debug?
       return if sandbox_mode?
 
-      # Actually add or update
-      payload = list_member_payload(member)
+      # Actually add or update. set_list_member applies status_if_new when the contact is new
+      payload = list_member_payload(member).merge(status_if_new: list_member_status(member))
       client.lists.set_list_member(member.mailchimp_list.mailchimp_id, subscriber_hash(member.user.email), payload)
     end
 
@@ -152,7 +152,7 @@ module Effective
 
       payload = {
         email_address: member.user.email,
-        status: (member.subscribed ? 'subscribed' : 'unsubscribed'),
+        status: list_member_status(member),
         merge_fields: merge_fields.transform_values { |value| value || '' },
         interests: member.interests_hash.presence
       }.compact
@@ -163,6 +163,10 @@ module Effective
       raise('expected an email') unless email.to_s.include?('@')
 
       Digest::MD5.hexdigest(email.to_s.downcase.strip)
+    end
+
+    def list_member_status(member)
+      member.subscribed ? 'subscribed' : 'unsubscribed'
     end
 
   end

--- a/test/models/mailchimp_api_test.rb
+++ b/test/models/mailchimp_api_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class MailchimpApiTest < ActiveSupport::TestCase
+  def api
+    @api ||= Effective::MailchimpApi.new(api_key: 'test-us1')
+  end
+
+  test 'subscriber_hash is the md5 of the lowercase email' do
+    expected = Digest::MD5.hexdigest('brenda.barrera@quadreal.com')
+
+    assert_equal expected, api.subscriber_hash('brenda.barrera@quadreal.com')
+  end
+
+  test 'subscriber_hash lowercases and strips before hashing' do
+    expected = Digest::MD5.hexdigest('brenda.barrera@quadreal.com')
+
+    assert_equal expected, api.subscriber_hash('  Brenda.Barrera@QuadReal.com  ')
+  end
+
+  test 'subscriber_hash raises without an email' do
+    assert_raises(RuntimeError) { api.subscriber_hash('not-an-email') }
+  end
+
+end


### PR DESCRIPTION
Three fixes to `Effective::MailchimpApi`, all surfaced while investigating recurring `MailchimpMarketing::ApiError` ("Member Exists") errors on member sync.

## 1. Subscriber hash for `set_list_member`
`list_member_add`/`list_member_update`/`list_member` passed the raw email where Mailchimp expects the `subscriber_hash` — the MD5 of the lowercased email. When the path identifier didn't resolve to the existing contact, even the PUT upsert collided and returned `400 "Member Exists. Use PUT to insert or update list members."`. Now we hash `MD5(downcase(email))`, and `list_member_update` reuses the stored `mailchimp_id` (which already is the subscriber hash) when present.

## 2. `status_if_new` on add
`set_list_member` is a PUT upsert: `status` updates an existing contact, while `status_if_new` is required to create a new one. The payload only sent `status`, so genuinely new subscribers failed validation. We now mirror the desired status into `status_if_new`.

## 3. Interest category / interest pagination
`categories` and `interests` omitted `count`, so Mailchimp's default page size of 10 silently truncated the results — lists with more than 10 interest categories, or a category with more than 10 groups, would drop the overflow and make those interests unsubscribable. Both now pass `count: 1000` (the endpoint maximum), matching the other index calls.

## Tests
Adds `test/models/mailchimp_api_test.rb` covering `subscriber_hash`. Full suite green (5/5).

Also syncs the gem's `Gemfile.lock` to the current 0.13.2 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)